### PR TITLE
feat: internal logging framework

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,52 @@
+class Logger {
+  static async log(data: string) {
+    await Bun.write(Bun.stdout, `${data}\n`);
+  }
+
+  static logo() {
+    const melonpan = `
+███╗░░░███╗███████╗██╗░░░░░░█████╗░███╗░░██╗██████╗░░█████╗░███╗░░██╗
+████╗░████║██╔════╝██║░░░░░██╔══██╗████╗░██║██╔══██╗██╔══██╗████╗░██║
+██╔████╔██║█████╗░░██║░░░░░██║░░██║██╔██╗██║██████╔╝███████║██╔██╗██║
+██║╚██╔╝██║██╔══╝░░██║░░░░░██║░░██║██║╚████║██╔═══╝░██╔══██║██║╚████║
+██║░╚═╝░██║███████╗███████╗╚█████╔╝██║░╚███║██║░░░░░██║░░██║██║░╚███║
+╚═╝░░░░░╚═╝╚══════╝╚══════╝░╚════╝░╚═╝░░╚══╝╚═╝░░░░░╚═╝░░╚═╝╚═╝░░╚══╝
+
+---------------------------------------------------------------------
+⚡️Blazing fast melonpan, up and running!
+`;
+    Logger.log(melonpan);
+  }
+
+  private colors = {
+    Reset: "\x1b[0m",
+
+    BgBlack: "\x1b[40m",
+    BgRed: "\x1b[41m",
+    BgGreen: "\x1b[42m",
+    BgYellow: "\x1b[43m",
+    BgBlue: "\x1b[44m",
+    BgMagenta: "\x1b[45m",
+    BgCyan: "\x1b[46m",
+    BgWhite: "\x1b[47m",
+
+    FgBlack: "\x1b[30m",
+  };
+
+  private colorMapper = {
+    GET: this.colors.BgGreen,
+    POST: this.colors.BgYellow,
+    DELETE: this.colors.BgRed,
+    PUT: this.colors.BgBlue,
+  };
+
+  async routeLogger(req: Request) {
+    const time = new Date();
+    const url = new URL(req.url);
+    const routeBuilder = `${time.toLocaleTimeString()} | ${
+      this.colorMapper[req.method] || this.colors.BgCyan
+    } ${req.method} ${this.colors.Reset} | ${url.pathname}`;
+    Logger.log(routeBuilder);
+  }
+}
+export default Logger;

--- a/lib/melopan.ts
+++ b/lib/melopan.ts
@@ -3,12 +3,45 @@ import RouterInternalUtility from "./routerHelper";
 import MelonContext from "./context";
 import { MelonMiddleware, Methods, RouteHandler, RouterMap } from "./types";
 import PathUtilities, { MelonQueryParams } from "./path_utilities";
+import Logger from "./logger";
+
+interface MelonpanOptions {
+  logging: boolean;
+  logo: boolean;
+}
 
 class Melonpan extends RouterEngine {
   private routerMapping: RouterMap;
 
-  constructor() {
+  private loggerEnabled: boolean;
+
+  private logger: Logger;
+
+  private parseOptions(options: MelonpanOptions) {
+    if (options.logging) {
+      this.loggerEnabled = true;
+      this.logger = new Logger();
+    }
+    if (options.logo) {
+      Logger.logo();
+    }
+  }
+
+  private log(req: Request): void {
+    this.logger.routeLogger(req);
+  }
+
+  constructor(options?: MelonpanOptions) {
     super(null);
+    const defaultOpts: MelonpanOptions = {
+      logo: true,
+      logging: true,
+    };
+    if (!options) {
+      this.parseOptions(defaultOpts);
+    } else {
+      this.parseOptions(options);
+    }
     this.routerMapping = new Map<string, RouterInternalUtility>();
   }
 
@@ -22,6 +55,9 @@ class Melonpan extends RouterEngine {
   }
 
   serve(req: Request): Response {
+    if (this.loggerEnabled) {
+      this.log(req);
+    }
     const ctx: MelonContext = new MelonContext();
     let path = Melonpan.sanitizeUrl(req.url);
     const method = Methods[req.method];

--- a/test/melonpan.queryparams.test.ts
+++ b/test/melonpan.queryparams.test.ts
@@ -2,7 +2,7 @@ import { it, expect } from "bun:test";
 import { Melonpan } from "../index";
 import { httpEndpoint } from "./helper";
 
-const melonpan = new Melonpan();
+const melonpan = new Melonpan({ logo: false, logging: false });
 const qp = "123";
 const qpp = "567";
 

--- a/test/router.middleware.test.ts
+++ b/test/router.middleware.test.ts
@@ -2,7 +2,7 @@ import { it, expect } from "bun:test";
 import { httpEndpoint } from "./helper";
 import { Melonpan, MelonRouter } from "../index";
 
-const melonpan = new Melonpan();
+const melonpan = new Melonpan({ logo: false, logging: false });
 
 it("checks middleware registration", async () => {
   const router = new MelonRouter();

--- a/test/router.routes.test.ts
+++ b/test/router.routes.test.ts
@@ -2,7 +2,7 @@ import { it, expect } from "bun:test";
 import { Melonpan, MelonRouter } from "../index";
 import { Data, data, httpEndpoint, parsedData } from "./helper";
 
-const melonpan = new Melonpan();
+const melonpan = new Melonpan({ logo: false, logging: false });
 
 it("checks route registration takes place", async () => {
   const router = new MelonRouter();

--- a/test/router.verbs.test.ts
+++ b/test/router.verbs.test.ts
@@ -2,7 +2,7 @@ import { it, expect } from "bun:test";
 import { data, parsedData, httpEndpoint, Data } from "./helper";
 import { Melonpan, MelonRouter } from "../index";
 
-const melonpan = new Melonpan();
+const melonpan = new Melonpan({ logo: false, logging: false });
 
 it("ensures GET Verb registers", async () => {
   const router = new MelonRouter();


### PR DESCRIPTION
- Adds `MelonpanOptions`
- Adds Request Logging
- Prints Melonpan logo at the start

![image](https://user-images.githubusercontent.com/31009634/191277925-d00fbe4f-4893-44c8-8acd-92accd68f4f1.png)
