### PR TITLE
Exporting more from root

### DIFF
--- a/lib/melopan.ts
+++ b/lib/melopan.ts
@@ -186,7 +186,5 @@ export {
   Melonpan, 
   MelonContext, 
   MelonMiddleware, 
-  MelonHandler,
-  Methods as MelonMethods, 
-  RouteHandler as MelonRouteHandler
+  MelonHandler
 };

--- a/lib/melopan.ts
+++ b/lib/melopan.ts
@@ -1,7 +1,7 @@
 import RouterEngine from "./router";
 import RouterInternalUtility from "./routerHelper";
 import MelonContext from "./context";
-import { MelonMiddleware, Methods, RouteHandler, RouterMap } from "./types";
+import { MelonMiddleware, Methods, RouteHandler, RouterMap, MelonHandler } from "./types";
 import PathUtilities, { MelonQueryParams } from "./path_utilities";
 import Logger from "./logger";
 
@@ -181,4 +181,12 @@ class Melonpan extends RouterEngine {
   }
 }
 
-export { RouterEngine as MelonRouter, Melonpan };
+export { 
+  RouterEngine as MelonRouter, 
+  Melonpan, 
+  MelonContext, 
+  MelonMiddleware, 
+  MelonHandler,
+  Methods as MelonMethods, 
+  RouteHandler as MelonRouteHandler
+};


### PR DESCRIPTION
Using typescript I had to go around looking for exports like `MelonContext` etc.  the root package should export these. At some level I also feel like the `Melon` prefix from these classes should be removed because they are adding stutter to names. But for now I am sticking to the original convention. 