### PR TITLE
Fix exported types errors

### DIFF
--- a/lib/melopan.ts
+++ b/lib/melopan.ts
@@ -184,7 +184,7 @@ class Melonpan extends RouterEngine {
 export { 
   RouterEngine as MelonRouter, 
   Melonpan, 
-  MelonContext, 
-  MelonMiddleware, 
-  MelonHandler
+  MelonContext
 };
+
+export type { MelonMiddleware, MelonHandler }


### PR DESCRIPTION
There is an error in the exporting statements. Typescript 3.8 introduces new syntax for type-only exports, which are not being used. This pull request will fix the problem.