### PR TITLE
Add CORS with default headers

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -21,6 +21,12 @@ interface IMelonContext {
 class MelonContext implements IMelonContext {
   [index: string]: any;
 
+  private headers: Headers;
+
+  constructor(headers) {
+    this.headers = headers;
+  }
+
   json(
     message: any,
     statusCode?: number,
@@ -28,6 +34,7 @@ class MelonContext implements IMelonContext {
   ): Response {
     return new Response(JSON.stringify(message), {
       status: statusCode ?? 200,
+      headers: this.headers,
       ...options,
     });
   }
@@ -37,7 +44,7 @@ class MelonContext implements IMelonContext {
     statusCode?: number,
     options?: IMelonResponseOptions
   ): Response {
-    return new Response(message, { status: statusCode ?? 200, ...options });
+    return new Response(message, { status: statusCode ?? 200, headers: this.headers, ...options });
   }
 }
 

--- a/lib/melopan.ts
+++ b/lib/melopan.ts
@@ -17,6 +17,8 @@ class Melonpan extends RouterEngine {
 
   private logger: Logger;
 
+  private headers: Headers = new Headers();
+
   private parseOptions(options: MelonpanOptions) {
     if (options.logging) {
       this.loggerEnabled = true;
@@ -54,11 +56,18 @@ class Melonpan extends RouterEngine {
     this.routerMapping.set(path, routerHelper);
   }
 
+  cors() {
+    this.headers.append("Access-Control-Allow-Origin", "*");
+    this.headers.append("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
+    this.headers.append("Access-Control-Allow-Headers", "X-PINGOTHER, Content-Type");
+    this.headers.append("Access-Control-Max-Age", "86400");
+  }
+
   serve(req: Request): Response {
     if (this.loggerEnabled) {
       this.log(req);
     }
-    const ctx: MelonContext = new MelonContext();
+    const ctx: MelonContext = new MelonContext(this.headers);
     let path = Melonpan.sanitizeUrl(req.url);
     const method = Methods[req.method];
     if (this.qpMap.size !== 0) {
@@ -125,7 +134,7 @@ class Melonpan extends RouterEngine {
       return defaultHandler.handler(mreq, mctx);
     }
     // If default handler is not found
-    return new Response(`cannot find ${path}`, { status: 404 });
+    return new Response(`cannot find ${path}`, { status: 404, headers: this.headers });
   }
 
   private static findHandlerfromMap(


### PR DESCRIPTION
![Captura de pantalla de 2022-10-17 20-50-11](https://user-images.githubusercontent.com/115972610/196306388-e38d73c0-a7e2-4725-b67f-499e5db770b8.png)
Fix: to add a new property `private headers: Headers;` in `Melonpan`, which contains all set headers, in order to pass them as a param in all the `new Response()` objects. So now we just need to call `melonpan.cors()` to set all the default headers, which are:
```
[
  ["Access-Control-Allow-Origin", "*"]
  ["Access-Control-Allow-Methods", "POST, GET, OPTIONS"]
  ["Access-Control-Allow-Headers", "X-PINGOTHER, Content-Type"]
  ["Access-Control-Max-Age", "86400"]
]
```