### PR TITLE
Add res as response option

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -5,6 +5,9 @@ interface IMelonResponseOptions {
 }
 
 interface IMelonContext {
+  res(
+    res: Response
+  );
   json(
     message: any,
     statusCode?: number,
@@ -20,6 +23,10 @@ interface IMelonContext {
 
 class MelonContext implements IMelonContext {
   [index: string]: any;
+
+  res(res: Response) {
+    return res
+  }
 
   json(
     message: any,


### PR DESCRIPTION
Without this pull request, there were be only two response options: `json` and `text`. It is necessary to have a `res` response option to send a simple `new Response()` object.